### PR TITLE
fix(read_edf): ignore `event_types` not found in `discrete`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/eyelinkio/edf/read_edf.py
+++ b/eyelinkio/edf/read_edf.py
@@ -221,6 +221,8 @@ def _read_raw_edf(fname):
     assert np.array_equal(orig_times, np.sort(orig_times))
     times = np.arange(len(orig_times), dtype=np.float64) / info["sfreq"]
     for key in event_types:
+        if key not in discrete:
+            continue
         for sub_key in ("stime", "etime"):
             if sub_key in discrete[key].dtype.names:
                 _adjust_time(discrete[key][sub_key], orig_times, times)


### PR DESCRIPTION
Handles the case where some of the event types ("saccades", "fixations", "blinks", "buttons", "inputs", "messages") are not available in the recorded EDF file
