### PR TITLE
ENH: Read and store "START" and "END" events from EDF file

### DIFF
--- a/src/eyelinkio/edf/read.py
+++ b/src/eyelinkio/edf/read.py
@@ -151,6 +151,8 @@ _ets2pp = dict(
     BUTTONEVENT="buttons",
     INPUTEVENT="inputs",
     MESSAGEEVENT="messages",
+    STARTEVENTS="starts",
+    ENDEVENTS="ends",
 )
 
 
@@ -209,7 +211,16 @@ def _read_raw_edf(fname):
     #
     discrete = res["discrete"]
     info = res["info"]
-    event_types = ("saccades", "fixations", "blinks", "buttons", "inputs", "messages")
+    event_types = (
+        "saccades",
+        "fixations",
+        "blinks",
+        "buttons",
+        "inputs",
+        "messages",
+        "starts",
+        "ends",
+        )
     info["sample_fields"] = info["sample_fields"][1:]  # omit time
 
     #
@@ -541,6 +552,10 @@ def _handle_end(edf, res, name):
             f = ["sttime", "buttons"]
         elif name == "inputs":
             f = ["sttime", "input"]
+        elif name == "starts":
+            f = ["sttime"]
+        elif name == "ends":
+            f = ["sttime"]
         else:
             raise KeyError(f"Unknown name {name}")
         res["edf_fields"][name] = f
@@ -592,7 +607,7 @@ _element_handlers = dict(
     BREAKPARSE=_handle_pass,
     STARTSAMPLES=_handle_pass,
     ENDSAMPLES=_handle_pass,
-    STARTEVENTS=_handle_pass,
-    ENDEVENTS=_handle_pass,
+    STARTEVENTS=partial(_handle_end, name="starts"),
+    ENDEVENTS=partial(_handle_end, name="ends"),
     VERSION=_handle_version,
 )

--- a/src/eyelinkio/tests/test_edf.py
+++ b/src/eyelinkio/tests/test_edf.py
@@ -25,6 +25,10 @@ def test_read_raw():
             # XXX: ideally we should get a binocular file with a calibration
             assert edf_file["info"]["eye"] == "BINOCULAR"
             assert len(edf_file["discrete"]["blinks"]) == 195
+            np.testing.assert_equal(edf_file["discrete"]["starts"]["stime"][0], 0.0)
+            np.testing.assert_almost_equal(
+                edf_file["discrete"]["ends"]["stime"][-1], 199.644
+                )
 
         elif fname.name == "test_2_raw.edf":  # First test file has this property
             for kind in ['saccades', 'fixations', 'blinks']:


### PR DESCRIPTION
Closes #17 

These events indicate when the Eye-tracker started and stopped recording, respectively. There can be multiple of these events, meaning that the eye-tracker started recording, paused, and then started recording again (e.g. during a calibration sequence or between trials). Sometimes there is a large time span between an `END` event and a subsequent `START` event, meaning there is a pause/gap in the recording that the user might want to know about.


The pyeparse authors appeared to know about "START" and "END events in EDF files, but they just used python's `pass` to skip these events when reading the EDF files.

I adjusted our event handlers to give both start and end events an entry in `EDF["discrete"]`.

For example

```python

import eyelinkio
fname = eyelinkio.utils._get_test_fnames()[2]
edf = eyelinkio.read_edf(fname)

edf["discrete"]["starts"]
```

```
array([(  0.   ,), ( 11.032,), ( 17.674,), ( 39.3  ,), ( 60.926,),
       ( 67.562,), ( 78.766,), ( 85.402,), ( 92.022,), ( 98.844,),
       (120.47 ,), (142.086,), (156.532,), (175.848,), (197.466,)],
      dtype=[('stime', '<f8')])
```

```python
edf["discrete"]["ends"]
```

```
array([( 11.0300007 ,), ( 17.67200078,), ( 39.29800084,), ( 60.92400067,),
       ( 67.56000069,), ( 78.76400077,), ( 85.40000075,), ( 92.02000076,),
       ( 98.84200089,), (120.46800086,), (142.0840008 ,), (156.53000088,),
       (175.84600069,), (197.4640009 ,), (199.644     ,)],
      dtype=[('stime', '<f8')])
```

and for reference, attached is an ASCII version of the same file used in the example above, where you can see the START and END events.

[test_raw_binocular.txt](https://github.com/user-attachments/files/18679253/test_raw_binocular.txt)


